### PR TITLE
Handle plus signs in gmail addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Implemented RuboCop, Ruby style linter - [@dblock](https://github.com/dblock).
 * Upgraded RSpec to 3.x syntax - [@dblock](https://github.com/dblock).
+* Implemented handling of '+' in Gmail addresses - [@jdpopkin](https://github.com/jdpopkin).
 
 ### 0.1.0 (6/22/2013)
 

--- a/lib/canonical-emails/gmail.rb
+++ b/lib/canonical-emails/gmail.rb
@@ -6,7 +6,7 @@ module CanonicalEmails
           email.instance_eval do
             def get_local
               value = super
-              value.gsub('.', '').downcase if value
+              value.gsub('.', '').downcase.gsub(/\+.*$/, '') if value
             end
 
             def domain

--- a/spec/canonical-emails/fixtures/gmail.yml
+++ b/spec/canonical-emails/fixtures/gmail.yml
@@ -27,3 +27,7 @@
   source: donald.duck@google.com
   local: donald.duck
   domain: google.com
+-
+  source: donald.duck+not.daffy@gmail.com
+  local: donaldduck
+  domain: gmail.com


### PR DESCRIPTION
Gmail ignores all text after a '+' in the local part of an email
address: an email sent to 'foo+bar@gmail.com' will arrive at
'foo@gmail.com'.
